### PR TITLE
Specify audio config in file instead of on command line

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -42,9 +42,6 @@ jobs:
 
       - name: Run examples
         run: |
-            # Required by google.sh
-            mkdir _out/
-
             convert -size 500x500 xc:none -fill white -draw "polygon 150,100 150,400 400,250" play_button.png
 
             ./examples/demo.sh

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ keys.env
 **/*.jpg
 **/*.pdf
 _out/
-tests/_out/
+tests/_cache_out/
 tests/_compatible_out/
 tests/_google_out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release.
 
-[0.4.0]: https://github.com/transformrs/trv/compare/v0.3.0...v0.4.0
+[0.3.1]: https://github.com/transformrs/trv/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/transformrs/trv/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/transformrs/trv/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/transformrs/trv/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ transformrs = "0.7"
 serde_json = "1.0.138"
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10.8"
+toml = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -32,13 +32,7 @@ To create a video, create a Typst presentation with speaker notes (we show only 
 Next, run the following command:
 
 ```raw
-$ trv --input=examples/first.typ \
-    --provider='openai-compatible(kokoros.transformrs.org)' \
-    --model=tts-1 \
-    --voice=af_sky \
-    --speed=0.95 \
-    --audio-format=wav \
-    --release
+$ trv --release build examples/first.typ
 ```
 
 This generates the following video:
@@ -99,11 +93,7 @@ Google has some high-quality voices available via their API:
 ```raw
 $ export GOOGLE_KEY="<YOUR KEY>"
 
-$ trv --input=examples/google.typ \
-    --provider=google \
-    --voice=en-US-Chirp-HD-D \
-    --language-code=en-US \
-    --release
+$ trv --release build examples/google.typ
 ```
 
 [![Google demo video](https://transformrs.github.io/trv/google.png)](https://transformrs.github.io/trv/google.mp4)
@@ -118,13 +108,20 @@ However, audio output is not yet available via the API.
 To use the Zyphra Zonos model, you need 8 GB of VRAM.
 So it's probably easiest to use DeepInfra:
 
+```typst
+#import "@preview/polylux:0.4.0": *
+
+// --- trv config:
+// provider = "deepinfra"
+// model = "Zyphra/Zonos-v0.1-hybrid"
+// voice = "american_male"
+// ---
+```
+
 ```raw
 $ export DEEPINFRA_KEY="<YOUR KEY>"
 
-$ trv --input=presentation.typ \
-    --model='Zyphra/Zonos-v0.1-hybrid' \
-    --voice='american_male' \
-    --release
+$ trv --release build presentation.typ
 ```
 
 Do note that Zonos is way more unstable than Kokoros at the time of writing.

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -4,8 +4,4 @@
 
 export GOOGLE_KEY=$(cat keys.env | grep GOOGLE_KEY | cut -d '=' -f 2)
 
-trv --input=examples/demo.typ \
-    --provider=google \
-    --voice=en-US-Chirp3-HD-Orus \
-    --language-code=en-US \
-    --release
+trv --release build examples/demo.typ

--- a/examples/demo.typ
+++ b/examples/demo.typ
@@ -5,6 +5,12 @@
 #set text(fill: white)
 #set text(size: 30pt)
 
+// --- trv config:
+// provider = "google"
+// voice = "en-US-Chirp3-HD-Orus"
+// language_code = "en-US"
+// ---
+
 #slide[
     #set text(size: 35pt)
     #align(center)[🔈]

--- a/examples/first.sh
+++ b/examples/first.sh
@@ -2,10 +2,4 @@
 
 # Run via `./examples/first.sh`
 
-trv --input=examples/first.typ \
-    --provider='openai-compatible(kokoros.transformrs.org)' \
-    --model=tts-1 \
-    --voice=af_sky \
-    --speed=0.95 \
-    --audio-format=wav \
-    --release
+trv --release build examples/first.typ

--- a/examples/first.typ
+++ b/examples/first.typ
@@ -2,6 +2,14 @@
 
 #set page(paper: "presentation-16-9")
 
+// --- trv config:
+// provider = "openai-compatible(kokoros.transformrs.org)"
+// model = "tts-1"
+// voice = "af_sky"
+// speed = 0.95
+// audio_format = "wav"
+// ---
+
 #slide[
     #set page(fill: black)
     #set text(fill: white)

--- a/examples/google.sh
+++ b/examples/google.sh
@@ -4,10 +4,4 @@
 
 export GOOGLE_KEY=$(cat keys.env | grep GOOGLE_KEY | cut -d '=' -f 2)
 
-cp examples/math.typ _out/math.typ
-
-trv --input=examples/google.typ \
-    --provider=google \
-    --voice=en-US-Chirp-HD-D \
-    --language-code=en-US \
-    --release
+trv --release build examples/google.typ

--- a/examples/google.typ
+++ b/examples/google.typ
@@ -3,6 +3,12 @@
 #set page(paper: "presentation-16-9")
 #set text(size: 25pt)
 
+// --- trv config:
+// provider = "google"
+// voice = "en-US-Chirp-HD-D"
+// language_code = "en-US"
+// ---
+
 #slide[
     #toolbox.pdfpc.speaker-note("
     This video was created with the Google text-to-speech API.

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,6 @@ fn parse_config(input: &PathBuf) -> Config {
     }
 
     let config_str = config_lines.join("\n");
-    println!("config_str: {config_str}");
     if config_str.is_empty() {
         return Config::default();
     }
@@ -188,7 +187,7 @@ fn include_includes(input_dir: &Path, content: &str) -> String {
         if line.starts_with("#include") {
             let include = line.split_whitespace().nth(1).unwrap().trim_matches('"');
             let include_path = input_dir.join(include);
-            tracing::info!("Including file: {}", include_path.display());
+            tracing::debug!("Including file: {}", include_path.display());
             let content = std::fs::read_to_string(include_path).unwrap();
             for line in content.lines() {
                 output.push_str(line);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -44,10 +44,10 @@ fn test_cache() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cmd = bin();
     cmd.env("DEEPINFRA_KEY", &key);
-    cmd.arg("build");
-    cmd.arg("tests/test_cache.typ");
     cmd.arg("--verbose");
     cmd.arg(format!("--out-dir={}", out_dir));
+    cmd.arg("build");
+    cmd.arg("tests/test_cache.typ");
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("Slide 1: Generating audio file"))

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -44,8 +44,8 @@ fn test_cache() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cmd = bin();
     cmd.env("DEEPINFRA_KEY", &key);
-    cmd.arg("--input=tests/test.typ");
-    cmd.arg("--audio-format=mp3");
+    cmd.arg("build");
+    cmd.arg("tests/test_cache.typ");
     cmd.arg("--verbose");
     cmd.arg(format!("--out-dir={}", out_dir));
     cmd.assert()
@@ -62,8 +62,8 @@ fn test_cache() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cmd = bin();
     cmd.env("DEEPINFRA_KEY", key);
-    cmd.arg("--input=tests/test.typ");
-    cmd.arg("--audio-format=mp3");
+    cmd.arg("build");
+    cmd.arg("tests/test_cache.typ");
     cmd.arg("--verbose");
     cmd.arg(format!("--out-dir={}", out_dir));
     cmd.assert()
@@ -105,11 +105,8 @@ fn openai_compatible_provider() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = bin();
     cmd.arg(format!("--out-dir={}", out_dir));
     cmd.arg("--verbose");
-    cmd.arg("--input=tests/test.typ");
-    cmd.arg("--provider=openai-compatible(kokoros.transformrs.org)");
-    cmd.arg("--model=tts-1");
-    cmd.arg("--voice=bm_lewis");
-    cmd.arg("--audio-format=wav");
+    cmd.arg("build");
+    cmd.arg("tests/test_openai_compatible.typ");
     cmd.arg("--release");
     cmd.assert().success();
 
@@ -149,10 +146,8 @@ fn google_provider() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg(format!("--out-dir={}", out_dir));
     cmd.arg("--verbose");
     cmd.env("GOOGLE_KEY", key);
-    cmd.arg("--provider=google");
-    cmd.arg("--input=tests/test.typ");
-    cmd.arg("--voice=en-US-Chirp-HD-D");
-    cmd.arg("--language-code=en-US");
+    cmd.arg("build");
+    cmd.arg("tests/test_google.typ");
     if common::is_ci() {
         cmd.arg("--audio-codec=opus");
     } else {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -18,7 +18,7 @@ fn unexpected_argument() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_cache() -> Result<(), Box<dyn std::error::Error>> {
-    let out_dir = Path::new("tests").join("_out");
+    let out_dir = Path::new("tests").join("_cache_out");
     let out_dir = out_dir.to_str().unwrap();
     println!("out_dir: {out_dir}");
     let provider = Provider::DeepInfra;
@@ -105,9 +105,9 @@ fn openai_compatible_provider() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = bin();
     cmd.arg(format!("--out-dir={}", out_dir));
     cmd.arg("--verbose");
+    cmd.arg("--release");
     cmd.arg("build");
     cmd.arg("tests/test_openai_compatible.typ");
-    cmd.arg("--release");
     cmd.assert().success();
 
     for file in &files {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -62,10 +62,10 @@ fn test_cache() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cmd = bin();
     cmd.env("DEEPINFRA_KEY", key);
-    cmd.arg("build");
-    cmd.arg("tests/test_cache.typ");
     cmd.arg("--verbose");
     cmd.arg(format!("--out-dir={}", out_dir));
+    cmd.arg("build");
+    cmd.arg("tests/test_cache.typ");
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("Slide 1: Generating audio file"))
@@ -143,17 +143,17 @@ fn google_provider() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let mut cmd = bin();
+    cmd.env("GOOGLE_KEY", key);
     cmd.arg(format!("--out-dir={}", out_dir));
     cmd.arg("--verbose");
-    cmd.env("GOOGLE_KEY", key);
-    cmd.arg("build");
-    cmd.arg("tests/test_google.typ");
+    cmd.arg("--release");
     if common::is_ci() {
         cmd.arg("--audio-codec=opus");
     } else {
         cmd.arg("--audio-codec=aac_at");
     }
-    cmd.arg("--release");
+    cmd.arg("build");
+    cmd.arg("tests/test_google.typ");
     cmd.assert().success();
 
     for file in files {

--- a/tests/test_cache.typ
+++ b/tests/test_cache.typ
@@ -7,6 +7,7 @@
 // With that, trv will automatically use the DeepInfra provider.
 
 // --- trv config:
+// voice = "am_adam"
 // audio_format = "mp3"
 // ---
 

--- a/tests/test_cache.typ
+++ b/tests/test_cache.typ
@@ -1,0 +1,39 @@
+#import "@preview/polylux:0.4.0": *
+
+#set page(paper: "presentation-16-9")
+#set text(size: 25pt)
+
+// This files assumes that the DEEPINFRA_KEY environment variable is set.
+// With that, trv will automatically use the DeepInfra provider.
+
+// --- trv config:
+// audio_format = "mp3"
+// ---
+
+#slide[
+    \
+    #align(center)[Code examples or code videos?]
+
+    #toolbox.pdfpc.speaker-note(
+        ```md
+        ...... What if you could show code in a video?
+        ```
+    )
+]
+
+#slide[
+    #set text(size: 20pt)
+
+    ```rust
+    #[tokio::main]
+    async fn main() {
+        println!("Hello, world!");
+    }
+    ```
+
+    #toolbox.pdfpc.speaker-note(
+        ```md
+        For example, take this code.
+        ```
+    )
+]

--- a/tests/test_google.typ
+++ b/tests/test_google.typ
@@ -1,8 +1,13 @@
 #import "@preview/polylux:0.4.0": *
 
 #set page(paper: "presentation-16-9")
-
 #set text(size: 25pt)
+
+// --- trv config:
+// provider = "google"
+// voice = "en-US-Chirp-HD-D"
+// language_code = "en-US"
+// ---
 
 #slide[
     \
@@ -31,4 +36,3 @@
         ```
     )
 ]
-

--- a/tests/test_openai_compatible.typ
+++ b/tests/test_openai_compatible.typ
@@ -1,0 +1,39 @@
+#import "@preview/polylux:0.4.0": *
+
+#set page(paper: "presentation-16-9")
+#set text(size: 25pt)
+
+// --- trv config:
+// provider = "openai-compatible(kokoros.transformrs.org)"
+// model = "tts-1"
+// voice = "bm_lewis"
+// audio_format = "wav"
+// ---
+
+#slide[
+    \
+    #align(center)[Code examples or code videos?]
+
+    #toolbox.pdfpc.speaker-note(
+        ```md
+        ...... What if you could show code in a video?
+        ```
+    )
+]
+
+#slide[
+    #set text(size: 20pt)
+
+    ```rust
+    #[tokio::main]
+    async fn main() {
+        println!("Hello, world!");
+    }
+    ```
+
+    #toolbox.pdfpc.speaker-note(
+        ```md
+        For example, take this code.
+        ```
+    )
+]


### PR DESCRIPTION
The command line settings where getting too long. Now, the audio settings are specified in the Typst file instead. For example:

```typst
#import "@preview/polylux:0.4.0": *

#set page(paper: "presentation-16-9")
#set text(size: 25pt)

// --- trv config:
// voice = "am_adam"
// audio_format = "mp3"
// ---

#slide[
    \
    #align(center)[Code examples or code videos?]

    #toolbox.pdfpc.speaker-note(
        ```md
        ...... What if you could show code in a video?
        ```
    )
]
```