### PR TITLE
Concat images and audio in single ffmpeg step

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -235,9 +235,8 @@ pub(crate) async fn build(
     .await;
     let output = "out.mp4";
     if release {
-        video::create_video_clips(out_dir, &slides, cache, &tts_config, &audio_ext);
         let audio_codec = audio_codec.unwrap();
-        video::combine_video(out_dir, &slides, output, &audio_codec);
+        video::combine_video(out_dir, &slides, output, &audio_codec, &audio_ext);
     }
     slides
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -29,20 +29,3 @@ pub fn audio_cache_key_path(dir: &str, slide: &Slide) -> PathBuf {
     let filename = format!("{idx}.audio.cache_key");
     Path::new(dir).join("audio").join(filename)
 }
-
-pub fn video_cache_key_path(dir: &str, slide: &Slide) -> PathBuf {
-    let idx = slide.idx;
-    let filename = format!("{idx}.video.cache_key");
-    Path::new(dir).join("video").join(filename)
-}
-
-pub fn video_dir_name() -> &'static str {
-    "video"
-}
-
-pub fn video_path(dir: &str, slide: &Slide) -> PathBuf {
-    let idx = slide.idx;
-    // Using mp4 by default because it is widely supported in browsers.
-    let filename = format!("{idx}.mp4");
-    Path::new(dir).join(video_dir_name()).join(filename)
-}

--- a/src/video.rs
+++ b/src/video.rs
@@ -124,7 +124,7 @@ pub(crate) fn combine_video(
         .arg("-movflags")
         .arg("faststart")
         .arg(output_path);
-    tracing::info!("FFmpeg command:\n{:?}", cmd);
+    tracing::debug!("FFmpeg command:\n{:?}", cmd);
     let output = cmd.output().expect("Failed to run ffmpeg command");
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,169 +1,13 @@
-use crate::path::image_path;
-use crate::path::video_cache_key_path;
-use crate::path::video_dir_name;
-use std::path::PathBuf;
-use crate::path::video_path;
 use crate::path::audio_path;
-use crate::path::PathStr;
+use crate::path::image_path;
 use crate::slide::Slide;
-use serde::Deserialize;
-use serde::Serialize;
-use sha2::Digest;
-use sha2::Sha256;
-use std::fs::File;
-use std::io::Read;
-use std::io::Write;
 use std::path::Path;
-use transformrs::text_to_speech::TTSConfig;
-
-#[derive(Debug, Serialize, Deserialize)]
-struct VideoCacheKey {
-    slide: Slide,
-    config: TTSConfig,
-    image_hash: Vec<u8>,
-}
-
-fn hash_file(path: &Path) -> Vec<u8> {
-    let mut file = File::open(path).unwrap();
-    let mut hasher = Sha256::new();
-    let mut buffer = Vec::new();
-    if file.read_to_end(&mut buffer).is_ok() {
-        hasher.update(&buffer);
-    }
-    hasher.finalize().to_vec()
-}
-
-fn write_cache_key(dir: &str, slide: &Slide, config: &TTSConfig) {
-    let image_path = image_path(dir, slide);
-    let image_hash = hash_file(&image_path);
-
-    let cache_key = VideoCacheKey {
-        slide: slide.clone(),
-        config: config.clone(),
-        image_hash,
-    };
-    let output_path = video_cache_key_path(dir, slide);
-    let mut file = File::create(output_path).unwrap();
-    file.write_all(serde_json::to_string(&cache_key).unwrap().as_bytes())
-        .unwrap();
-}
-
-fn is_cached(dir: &str, slide: &Slide, config: &TTSConfig) -> bool {
-    let key_path = video_cache_key_path(dir, slide);
-    let video_path = video_path(dir, slide);
-    if !key_path.exists() || !video_path.exists() {
-        return false;
-    }
-    let stored_key = std::fs::read_to_string(key_path).unwrap();
-    let image_path = image_path(dir, slide);
-    let image_hash = hash_file(&image_path);
-    let cache_key = VideoCacheKey {
-        slide: slide.clone(),
-        config: config.clone(),
-        image_hash,
-    };
-    let current_info = serde_json::to_string(&cache_key).unwrap();
-    stored_key == current_info
-}
-
-fn generate_concat_list(dir: &str, slides: &Vec<Slide>) -> String {
-    let mut lines = Vec::new();
-    for slide in slides {
-        let path = crate::path::video_path(dir, slide);
-        let filename = path.file_name().unwrap();
-        let path = Path::new(video_dir_name()).join(filename);
-        let path = path.to_string();
-        let line = format!("file '{path}'");
-        lines.push(line);
-    }
-    // Do not sort the lines here or concat will place 10 and 11 before 2!
-    // lines.sort();
-    lines.join("\n")
-}
-
-fn set_default_ffmpeg_video_args(cmd: &mut std::process::Command) {
-    cmd.arg("-c:v")
-        .arg("libx264")
-        .arg("-crf")
-        .arg("23")
-        .arg("-preset")
-        .arg("fast")
-        .arg("-vf")
-        .arg(format!("scale=-1:{HEIGHT},format=yuv420p"))
-        .arg("-pix_fmt")
-        .arg("yuv420p");
-}
-
-fn write_concat_list(dir: &str, path: &str, slides: &Vec<Slide>) {
-    let concat_list = generate_concat_list(dir, slides);
-    std::fs::write(path, concat_list).expect("couldn't write concat list");
-}
+use std::path::PathBuf;
 
 // 1920 is the height of a HD YouTube Short.
 // It should be a good height for landscape videos too.
 // Since the video consists of images, data-wise it should be not a problem to go for a higher resolution.
 const HEIGHT: i32 = 1920;
-
-fn create_video_clip(dir: &str, slide: &Slide, cache: bool, config: &TTSConfig, ext: &str) {
-    tracing::info!("Slide {}: Generating video file...", slide.idx);
-    let input_audio = crate::path::audio_path(dir, slide, ext);
-    let input_image = crate::path::image_path(dir, slide);
-    let is_cached = cache && is_cached(dir, slide, config);
-    if is_cached {
-        tracing::info!(
-            "Slide {}: Skipping video generation due to cache",
-            slide.idx
-        );
-        return;
-    }
-    let output_video = crate::path::video_path(dir, slide);
-    let mut cmd = std::process::Command::new("ffmpeg");
-    cmd.arg("-y")
-        .arg("-loop")
-        .arg("1")
-        .arg("-i")
-        .arg(input_image)
-        .arg("-i")
-        .arg(input_audio);
-    set_default_ffmpeg_video_args(&mut cmd);
-    cmd.arg("-c:a")
-        .arg("opus")
-        .arg("-strict")
-        .arg("experimental")
-        .arg("-shortest")
-        .arg("-tune")
-        .arg("stillimage")
-        .arg(output_video.clone());
-    let output = cmd.output().expect("Failed to run ffmpeg command");
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        tracing::error!("Failed to create video clip: {stderr}");
-        std::process::exit(1);
-    }
-    if cache && !is_cached {
-        write_cache_key(dir, slide, config);
-    }
-}
-
-pub(crate) fn create_video_clips(
-    dir: &str,
-    slides: &Vec<Slide>,
-    cache: bool,
-    config: &TTSConfig,
-    audio_ext: &str,
-) {
-    {
-        let slide = slides.first().unwrap();
-        let output_video = crate::path::video_path(dir, slide);
-        let parent = output_video.parent().unwrap();
-        if !parent.exists() {
-            std::fs::create_dir_all(parent).unwrap();
-        }
-    }
-    for slide in slides {
-        create_video_clip(dir, slide, cache, config, audio_ext);
-    }
-}
 
 fn probe_duration(path: &PathBuf) -> Option<String> {
     let output = std::process::Command::new("ffprobe")
@@ -194,7 +38,7 @@ fn video_output_name(slide: &Slide) -> String {
 
 enum Stream {
     Audio,
-    Video
+    Video,
 }
 
 fn stream_index(slide: &Slide, stream: Stream) -> usize {
@@ -208,13 +52,16 @@ fn stream_index(slide: &Slide, stream: Stream) -> usize {
     }
 }
 
-pub(crate) fn combine_video(dir: &str, slides: &Vec<Slide>, output: &str, audio_codec: &str, audio_ext: &str) {
-    tracing::info!("Combining video clips into one video...");
+pub(crate) fn combine_video(
+    dir: &str,
+    slides: &Vec<Slide>,
+    output: &str,
+    audio_codec: &str,
+    audio_ext: &str,
+) {
+    tracing::info!("Combining images and audio into one video...");
     let output = Path::new(dir).join(output);
     let output_path = output.to_str().unwrap();
-    let concat_list = Path::new(dir).join("concat_list.txt");
-    let concat_list = concat_list.to_str().unwrap();
-    write_concat_list(dir, concat_list, slides);
 
     let mut cmd = std::process::Command::new("ffmpeg");
     cmd.arg("-y");
@@ -223,45 +70,59 @@ pub(crate) fn combine_video(dir: &str, slides: &Vec<Slide>, output: &str, audio_
         cmd.arg("-i").arg(&audio_path);
         let image_path = image_path(dir, slide);
         let duration = probe_duration(&audio_path).unwrap();
-        cmd.arg("-loop").arg("1").arg("-framerate").arg("1").arg("-t").arg(duration).arg("-i").arg(image_path);
+        cmd.arg("-loop")
+            .arg("1")
+            .arg("-framerate")
+            .arg("1")
+            .arg("-t")
+            .arg(duration)
+            .arg("-i")
+            .arg(image_path);
     }
-    let video_filters = slides.iter().map(|slide| {
-        let input_index = stream_index(slide, Stream::Video);
-        let output_name = video_output_name(slide);
-        format!("[{input_index}:v]scale=-1:{HEIGHT},format=yuv420p[{output_name}];")
-    }).collect::<Vec<String>>();
-    let inputs = slides.iter().map(|slide| {
-        let video_output_name = video_output_name(slide);
-        let audio_index = stream_index(slide, Stream::Audio);
-        format!("[{video_output_name}][{audio_index}:a]")
-    }).collect::<Vec<String>>();
-    let filter = format!("{} {} concat=n=2:v=1:a=1 [outv] [outa]", video_filters.join(" "), inputs.join(""));
-    tracing::debug!("Video filter: {}", filter);
+    let video_filters = slides
+        .iter()
+        .map(|slide| {
+            let input_index = stream_index(slide, Stream::Video);
+            let output_name = video_output_name(slide);
+            format!("[{input_index}:v]scale=-1:{HEIGHT},format=yuv420p[{output_name}];")
+        })
+        .collect::<Vec<String>>();
+    let inputs = slides
+        .iter()
+        .map(|slide| {
+            let video_output_name = video_output_name(slide);
+            let audio_index = stream_index(slide, Stream::Audio);
+            format!("[{video_output_name}][{audio_index}:a]")
+        })
+        .collect::<Vec<String>>();
+    let filter = format!(
+        "{} {} concat=n=2:v=1:a=1 [outv] [outa]",
+        video_filters.join(" "),
+        inputs.join("")
+    );
     cmd.arg("-filter_complex")
         .arg(filter)
-    .arg("-map")
-    .arg("[outv]")
-    // Re-encode to 30 fps since most video players don't like 1 fps.
-    .arg("-r")
-    .arg("30")
-    .arg("-map")
-    .arg("[outa]")
-    .arg("-tune")
-    .arg("stillimage")
-    // Experimental is required for opus.
-    .arg("-strict")
-    .arg("-2")
-    // Default audio codec is aac which has poor quality.
-    .arg("-c:a")
-    .arg(audio_codec)
-    // Move some data to the beginning for faster playback start.
-    .arg("-movflags")
-    .arg("faststart")
-    .arg(output_path);
+        .arg("-map")
+        .arg("[outv]")
+        // Re-encode to 30 fps since most video players don't like 1 fps.
+        .arg("-r")
+        .arg("30")
+        .arg("-map")
+        .arg("[outa]")
+        .arg("-tune")
+        .arg("stillimage")
+        // Experimental is required for opus.
+        .arg("-strict")
+        .arg("-2")
+        // Default audio codec is aac which has poor quality.
+        .arg("-c:a")
+        .arg(audio_codec)
+        // Move some data to the beginning for faster playback start.
+        .arg("-movflags")
+        .arg("faststart")
+        .arg(output_path);
     tracing::debug!("FFmpeg command:\n{:?}", cmd);
-    let output = cmd
-        .output()
-        .expect("Failed to run ffmpeg command");
+    let output = cmd.output().expect("Failed to run ffmpeg command");
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         tracing::error!("Failed to concat video clips: {stderr}");

--- a/src/video.rs
+++ b/src/video.rs
@@ -96,9 +96,10 @@ pub(crate) fn combine_video(
         })
         .collect::<Vec<String>>();
     let filter = format!(
-        "{} {} concat=n=2:v=1:a=1 [outv] [outa]",
+        "{} {} concat=n={}:v=1:a=1 [outv] [outa]",
         video_filters.join(" "),
-        inputs.join("")
+        inputs.join(""),
+        slides.len()
     );
     cmd.arg("-filter_complex")
         .arg(filter)
@@ -117,11 +118,13 @@ pub(crate) fn combine_video(
         // Default audio codec is aac which has poor quality.
         .arg("-c:a")
         .arg(audio_codec)
+        // Try to avoid pauses.
+        .arg("-shortest")
         // Move some data to the beginning for faster playback start.
         .arg("-movflags")
         .arg("faststart")
         .arg(output_path);
-    tracing::debug!("FFmpeg command:\n{:?}", cmd);
+    tracing::info!("FFmpeg command:\n{:?}", cmd);
     let output = cmd.output().expect("Failed to run ffmpeg command");
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -29,10 +29,6 @@ fn test_cache() -> Result<(), Box<dyn std::error::Error>> {
         "audio/1.mp3",
         "audio/2.mp3",
         "audio/1.audio.cache_key",
-        "video/1.mp4",
-        "video/2.mp4",
-        "video/1.video.cache_key",
-        "concat_list.txt",
         "out.mp4",
     ];
     for file in &files {
@@ -71,9 +67,6 @@ fn test_cache() -> Result<(), Box<dyn std::error::Error>> {
         .stdout(predicate::str::contains("Slide 1: Generating audio file"))
         .stdout(predicate::str::contains(
             "Slide 1: Skipping audio generation due to cache",
-        ))
-        .stdout(predicate::str::contains(
-            "Slide 1: Skipping video generation due to cache",
         ));
 
     Ok(())
@@ -90,8 +83,6 @@ fn openai_compatible_provider() -> Result<(), Box<dyn std::error::Error>> {
         "audio/1.wav",
         "audio/2.wav",
         "audio/1.audio.cache_key",
-        "video/1.mp4",
-        "concat_list.txt",
         "out.mp4",
     ];
     for file in &files {
@@ -128,8 +119,6 @@ fn google_provider() -> Result<(), Box<dyn std::error::Error>> {
         "audio/1.mp3",
         "audio/2.mp3",
         "audio/1.audio.cache_key",
-        "video/1.mp4",
-        "concat_list.txt",
         "out.mp4",
     ];
     for file in &files {
@@ -221,7 +210,7 @@ fn test_duration_matches() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = bin();
     cmd.env("GOOGLE_KEY", key);
     cmd.arg(format!("--out-dir={}", out_dir));
-    cmd.arg("--verbose");
+    // cmd.arg("--verbose");
     cmd.arg("--cache=false");
     cmd.arg("build");
     cmd.arg("tests/test_duration_matches.typ");
@@ -241,7 +230,7 @@ fn test_duration_matches() -> Result<(), Box<dyn std::error::Error>> {
     println!("audio_duration: {audio_duration}");
     let audio_duration = duration_as_seconds(&audio_duration);
     println!("audio_duration: {audio_duration} seconds");
-    assert!(video_duration - audio_duration < 0.1);
+    assert!(video_duration - audio_duration < 0.01);
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #34.

This seems to work great. CI running times are halved and when generating subtitles on a video that has 20 slides and takes multiple minutes all subtitles remain in sync for the duration of the video (related to https://github.com/transformrs/trv/pull/25) 🚀. 

This is an example of the command that the code generates:

```sh
$ ffmpeg \
    -i _out/audio/1.wav \
    -loop 1 -framerate 1 -t "00:00:04.93" -i _out/image/1.png \
    -i _out/audio/2.wav \
    -loop 1 -framerate 1 -t "00:00:07.48" -i _out/image/2.png \
    -filter_complex \
    "
    [1:v]scale=-1:1080,format=yuv420p[v0]; \
    [3:v]scale=-1:1080,format=yuv420p[v1]; \
    [v0][0:a][v1][2:a] concat=n=2:v=1:a=1 [outv] [outa] \
    " \
    -map "[outv]" -r 30 -map "[outa]" -tune stillimage \
    -c:a opus \
    -strict -2 \
    -shortest \
    -movflags \
    +faststart \
    _out/out.mp4 
```