### PR TITLE
Fix caching for audio with ElevenLabs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-transformrs = "0.8"
+transformrs = { path = "../transformrs" }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-transformrs = { path = "../transformrs" }
+transformrs = "1.0"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -13,7 +13,7 @@ use transformrs::Key;
 use transformrs::Keys;
 use transformrs::Provider;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct AudioCacheKey {
     text: String,
     config: TTSConfig,
@@ -39,13 +39,13 @@ fn is_cached(dir: &str, slide: &Slide, config: &TTSConfig, audio_ext: &str) -> b
         return false;
     }
     let stored_key = std::fs::read_to_string(txt_path).unwrap();
+    let stored_key = serde_json::from_str::<AudioCacheKey>(&stored_key).unwrap();
     let text = slide.speaker_note.clone();
     let cache_key = AudioCacheKey {
         text,
         config: config.clone(),
     };
-    let current_info = serde_json::to_string(&cache_key).unwrap();
-    stored_key == current_info
+    stored_key == cache_key
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
With ElevenLabs the `other` key was used which was a `HashMap` and therefore not correctly compared. 

Fixes #44 